### PR TITLE
`hpos-hc-connect/hha_types`: Add hha struct

### DIFF
--- a/crates/core_app_cli/src/actions/get_specific_happ_prefs.rs
+++ b/crates/core_app_cli/src/actions/get_specific_happ_prefs.rs
@@ -4,7 +4,8 @@ use hpos_hc_connect::{hha_types::HappPreferences, CoreAppAgent, CoreAppRoleName}
 
 pub async fn get(pref_hash: String) -> Result<()> {
     let mut agent = CoreAppAgent::connect().await?;
-    let pref_holo_hash = ActionHashB64::from_b64_str(&pref_hash)?;
+    let pref_holo_hash = ActionHashB64::from_b64_str(&pref_hash)
+        .expect("Failed to serialize string into ActionHashB4");
     let hash = ActionHash::from(pref_holo_hash);
 
     let result = agent
@@ -15,6 +16,8 @@ pub async fn get(pref_hash: String) -> Result<()> {
             ExternIO::encode(hash)?,
         )
         .await?;
+
+    println!("ZOME CALL RESULT: {:?}", result);
 
     let prefs: HappPreferences = rmp_serde::from_slice(result.as_bytes())?;
 

--- a/crates/hpos_connect_hc/src/hha_types.rs
+++ b/crates/hpos_connect_hc/src/hha_types.rs
@@ -4,6 +4,12 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct HappAndHost {
+    pub happ_id: ActionHashB64,
+    pub holoport_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct HappPreferences {
     pub max_fuel_before_invoice: Fuel,
     pub price_compute: Fuel,
@@ -32,6 +38,7 @@ pub struct HoloportDetails {
     pub preferences: Option<HappPreferences>,
     pub preferences_hash: Option<ActionHashB64>,
 }
+
 #[derive(Debug, Serialize, Deserialize, SerializedBytes)]
 pub struct PresentedHappBundle {
     pub id: ActionHashB64,


### PR DESCRIPTION
### Updates
 - Add `HappAndHost` struct.
 > NB: This is needed in the envo\y-chaperone rust tests.