### PR TITLE
0.4 connection fix

### DIFF
--- a/crates/hpos_connect_hc/src/admin_ws.rs
+++ b/crates/hpos_connect_hc/src/admin_ws.rs
@@ -209,7 +209,7 @@ impl AdminWebsocket {
     pub async fn send(&mut self, msg: AdminRequest) -> Result<AdminResponse> {
         let response = self
             .tx
-            .request(msg)
+            .request_timeout(msg, std::time::Duration::from_secs(600))
             .await
             .context("failed to send message")?;
         match response {

--- a/crates/hpos_connect_hc/src/admin_ws.rs
+++ b/crates/hpos_connect_hc/src/admin_ws.rs
@@ -82,7 +82,9 @@ impl AdminWebsocket {
         &mut self,
         status_filter: Option<AppStatusFilter>,
     ) -> Result<Vec<InstalledAppId>> {
-        let response = self.send(AdminRequest::ListApps { status_filter }, None).await?;
+        let response = self
+            .send(AdminRequest::ListApps { status_filter }, None)
+            .await?;
         match response {
             AdminResponse::AppsListed(info) => {
                 Ok(info.iter().map(|i| i.installed_app_id.to_owned()).collect())
@@ -189,7 +191,9 @@ impl AdminWebsocket {
         &mut self,
         status_filter: Option<AppStatusFilter>,
     ) -> Result<Vec<AppInfo>> {
-        let response = self.send(AdminRequest::ListApps { status_filter }, None).await?;
+        let response = self
+            .send(AdminRequest::ListApps { status_filter }, None)
+            .await?;
         match response {
             AdminResponse::AppsListed(apps_infos) => Ok(apps_infos),
             _ => unreachable!("Unexpected response {:?}", response),
@@ -206,10 +210,14 @@ impl AdminWebsocket {
     }
 
     #[instrument(skip(self))]
-    pub async fn send(&mut self, msg: AdminRequest, duration: Option<u64>) -> Result<AdminResponse> {
+    pub async fn send(
+        &mut self,
+        msg: AdminRequest,
+        duration: Option<u64>,
+    ) -> Result<AdminResponse> {
         // default timeout is 60 seconds
         let timeout_duration = std::time::Duration::from_secs(duration.unwrap_or(60));
-        
+
         let response = self
             .tx
             .request_timeout(msg, timeout_duration)


### PR DESCRIPTION
WASM compile step is now part of the install_app call itself. Fore core-apps this is 45 seconds and causes install to timeout if using the default 60 seconds. 

I don't know how long we really need but I set 5 minutes just in case.