### PR TITLE
Adds support for creating clone cells & making zome calls by clone name.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2186,6 +2186,7 @@ dependencies = [
  "again",
  "anyhow",
  "base64 0.13.1",
+ "chrono",
  "ed25519-dalek",
  "getrandom 0.2.15",
  "holochain_conductor_api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const_env"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e9e4f72c6e3398ca6da372abd9affd8f89781fe728869bbf986206e9af9627e"
+dependencies = [
+ "const_env_impl",
+]
+
+[[package]]
+name = "const_env_impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f51209740b5e1589e702b3044cdd4562cef41b6da404904192ffffb852d62"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,6 +2302,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.1",
  "chrono",
+ "const_env",
  "ed25519-dalek",
  "getrandom 0.2.15",
  "holochain_conductor_api",

--- a/crates/configure-holochain/src/lib.rs
+++ b/crates/configure-holochain/src/lib.rs
@@ -43,7 +43,7 @@ pub async fn install_happs(happ_file: &HappsFile, config: &Config) -> Result<()>
     debug!("Getting a list of active happ");
     let active_happs = Arc::new(
         admin_websocket
-            .list_running_app()
+            .list_enabled_apps()
             .await
             .context("failed to get installed hApps")?,
     );

--- a/crates/configure-holochain/tests/config.yaml
+++ b/crates/configure-holochain/tests/config.yaml
@@ -3,11 +3,11 @@
     [
       {
         'app_id': 'core-app',
-        'bundle_url': 'https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/core-app/0_6_1/core-app.0_6_1-skip-proof.happ',
+        'bundle_url': 'https://holo-host.github.io/holo-hosting-app-rsm/releases/downloads/core-app/0_6_2/core-app.0_6_2-skip-proof.happ',
       },
       {
         'app_id': 'servicelogger',
-        'bundle_url': 'https://holo-host.github.io/servicelogger-rsm/releases/downloads/0_5_1/servicelogger.0_5_1.happ',
+        'bundle_url': 'https://holo-host.github.io/servicelogger-rsm/releases/downloads/0_5_4/servicelogger.0_5_4.happ',
       },
     ],
   'self_hosted_happs':

--- a/crates/configure-holochain/tests/integration.rs
+++ b/crates/configure-holochain/tests/integration.rs
@@ -146,7 +146,7 @@ async fn run_configure_holochain(f_r_a_k: &str, r_o_m_p: &str) {
         .unwrap();
 
     let happs = connection
-        .list_running_app()
+        .list_enabled_apps()
         .await
         .context("failed to get installed hApps")
         .unwrap();

--- a/crates/configure-holochain/tests/integration.rs
+++ b/crates/configure-holochain/tests/integration.rs
@@ -40,7 +40,7 @@ use test_case::test_case;
 
 /// Testing scenario for holoport running on alphaNet
 /// FORCE_RANDOM_AGENT_KEY="", READ_ONLY_MEM_PROOF="false"
-// #[test_case("", "false" ; "holoport on alpha net")]
+#[test_case("", "false" ; "holoport on alpha net")]
 /// Testing scenario for holoport running on devNet
 /// FORCE_RANDOM_AGENT_KEY="1", READ_ONLY_MEM_PROOF="false"
 #[test_case("1", "false" ; "holoport on dev net")]

--- a/crates/configure-holochain/tests/integration.rs
+++ b/crates/configure-holochain/tests/integration.rs
@@ -40,7 +40,7 @@ use test_case::test_case;
 
 /// Testing scenario for holoport running on alphaNet
 /// FORCE_RANDOM_AGENT_KEY="", READ_ONLY_MEM_PROOF="false"
-#[test_case("", "false" ; "holoport on alpha net")]
+// #[test_case("", "false" ; "holoport on alpha net")]
 /// Testing scenario for holoport running on devNet
 /// FORCE_RANDOM_AGENT_KEY="1", READ_ONLY_MEM_PROOF="false"
 #[test_case("1", "false" ; "holoport on dev net")]

--- a/crates/hpos_connect_hc/Cargo.toml
+++ b/crates/hpos_connect_hc/Cargo.toml
@@ -33,3 +33,4 @@ holochain_keystore = { workspace = true }
 sodoken = { workspace = true }
 url2 = "0.0.6"
 holofuel_types = { workspace = true }
+chrono = "0.4.19"

--- a/crates/hpos_connect_hc/Cargo.toml
+++ b/crates/hpos_connect_hc/Cargo.toml
@@ -34,3 +34,4 @@ sodoken = { workspace = true }
 url2 = "0.0.6"
 holofuel_types = { workspace = true }
 chrono = "0.4.19"
+const_env = "0.1"

--- a/crates/hpos_connect_hc/src/admin_ws.rs
+++ b/crates/hpos_connect_hc/src/admin_ws.rs
@@ -93,11 +93,9 @@ impl AdminWebsocket {
         }
     }
 
-    pub async fn list_running_app(&mut self) -> Result<Vec<InstalledAppId>> {
-        let mut running = self.list_app(Some(AppStatusFilter::Running)).await?;
-        let mut enabled = self.list_app(Some(AppStatusFilter::Enabled)).await?;
-        running.append(&mut enabled);
-        Ok(running)
+    pub async fn list_enabled_apps(&mut self) -> Result<Vec<InstalledAppId>> {
+        let enabled = self.list_app(Some(AppStatusFilter::Enabled)).await?;
+        Ok(enabled)
     }
 
     #[instrument(skip(self, app, membrane_proofs, agent))]

--- a/crates/hpos_connect_hc/src/admin_ws.rs
+++ b/crates/hpos_connect_hc/src/admin_ws.rs
@@ -4,7 +4,6 @@ use super::holo_config::Happ;
 use super::hpos_agent::Agent;
 use super::hpos_membrane_proof::MembraneProofs;
 use anyhow::{anyhow, Context, Result};
-use chrono::Duration;
 use holochain_conductor_api::{
     AdminRequest, AdminResponse, AppAuthenticationToken, AppAuthenticationTokenIssued, AppInfo,
     AppStatusFilter, IssueAppAuthenticationTokenPayload,

--- a/crates/hpos_connect_hc/src/admin_ws.rs
+++ b/crates/hpos_connect_hc/src/admin_ws.rs
@@ -4,12 +4,13 @@ use super::holo_config::Happ;
 use super::hpos_agent::Agent;
 use super::hpos_membrane_proof::MembraneProofs;
 use anyhow::{anyhow, Context, Result};
+use chrono::Duration;
 use holochain_conductor_api::{
     AdminRequest, AdminResponse, AppAuthenticationToken, AppAuthenticationTokenIssued, AppInfo,
     AppStatusFilter, IssueAppAuthenticationTokenPayload,
 };
 use holochain_types::{
-    app::{InstallAppPayload, InstalledAppId},
+    app::{DeleteCloneCellPayload, InstallAppPayload, InstalledAppId},
     dna::AgentPubKey,
     websocket::AllowedOrigins,
 };
@@ -204,6 +205,16 @@ impl AdminWebsocket {
         match response {
             AdminResponse::AgentPubKeyGenerated(key) => Ok(key),
             _ => unreachable!("Unexpected response {:?}", response),
+        }
+    }
+
+    /// Deletes a clone cell
+    pub async fn delete_clone(&mut self, payload: DeleteCloneCellPayload) -> Result<()> {
+        let admin_request = AdminRequest::DeleteCloneCell(Box::new(payload.clone()));
+        let response = self.send(admin_request, None).await?;
+        match response {
+            AdminResponse::CloneCellDeleted => Ok(()),
+            _ => Err(anyhow!("Error creating clone {:?}", payload)),
         }
     }
 

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -9,14 +9,8 @@ use holochain_conductor_api::{
 };
 use holochain_keystore::MetaLairClient;
 use holochain_types::{
-    app::{
-        CreateCloneCellPayload, DeleteCloneCellPayload, DisableCloneCellPayload,
-        EnableCloneCellPayload,
-    },
-    prelude::{
-        CellId, ClonedCell, EnableCloneCellInput, ExternIO, FunctionName, RoleName,
-        ZomeCallUnsigned, ZomeName,
-    },
+    app::{CreateCloneCellPayload, DisableCloneCellPayload, EnableCloneCellPayload},
+    prelude::{CellId, ClonedCell, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName},
 };
 use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
 use serde::{de::DeserializeOwned, Serialize};

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -113,8 +113,8 @@ impl AppConnection {
         }
     }
 
-    /// Returns a all cloned cells for a given RoleName in a connected app
-    pub async fn clone_cells(&mut self, role_name: RoleName) -> Result<Vec<ClonedCell>> {
+    /// Returns all cloned cells for a given RoleName in a connected app
+    pub async fn cloned_cells(&mut self, role_name: RoleName) -> Result<Vec<ClonedCell>> {
         let info = &self.cell_info().await?;
         let app_cells = info
             .get(&role_name)

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -9,8 +9,8 @@ use holochain_conductor_api::{
 };
 use holochain_keystore::MetaLairClient;
 use holochain_types::{
-    app::CreateCloneCellPayload,
-    prelude::{CellId, ClonedCell, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName},
+    app::{CreateCloneCellPayload, DeleteCloneCellPayload, DisableCloneCellPayload, EnableCloneCellPayload},
+    prelude::{CellId, ClonedCell, EnableCloneCellInput, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName},
 };
 use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
 use serde::{de::DeserializeOwned, Serialize};
@@ -159,6 +159,26 @@ impl AppConnection {
         }
     }
 
+    /// Disables a clone cell
+    pub async fn disable_clone(&mut self, payload: DisableCloneCellPayload) -> Result<()> {
+        let app_request = AppRequest::DisableCloneCell(Box::new(payload.clone()));
+        let response = self.send(app_request,).await?;
+        match response {
+            AppResponse::CloneCellDisabled => Ok(()),
+            _ => Err(anyhow!("Error disabling clone {:?}", payload)),
+        }
+    }
+
+    /// Enable a clone cell
+    pub async fn enable_clone(&mut self, payload: EnableCloneCellPayload) -> Result<ClonedCell> {
+        let app_request = AppRequest::EnableCloneCell(Box::new(payload.clone()));
+        let response = self.send(app_request,).await?;
+        match response {
+            AppResponse::CloneCellEnabled(cloned_cell) => Ok(cloned_cell),
+            _ => Err(anyhow!("Error enabling clone {:?}", payload)),
+        }
+    }
+    
     /// Raw zome call function taking holochain_conductor_api::app_interface::ZomeCall as an argument
     /// and returning AppResponse without checking an outcomeor deserializing
     #[instrument(skip(self))]

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -130,9 +130,9 @@ impl AppConnection {
     }
 
     /// Returns a cell for a given RoleName and CloneName in a connected app
-    pub async fn clone_cell(&mut self, role_name: RoleName, clone_name: String) -> Result<CellId> {
-        let clone_cells = self.clone_cells(role_name.clone()).await?;
-        let cell = clone_cells
+    pub async fn cloned_cell_id(&mut self, role_name: RoleName, clone_name: String) -> Result<CellId> {
+        let cloned_cells = self.cloned_cells(role_name.clone()).await?;
+        let cell = cloned_cells
             .into_iter()
             .find_map(|cell| {
                 if cell.name == clone_name {
@@ -273,7 +273,7 @@ impl AppConnection {
         T: Serialize + Debug,
         R: DeserializeOwned,
     {
-        let cell_id = self.clone_cell(role_name, clone_name).await?;
+        let cell_id = self.cloned_cell_id(role_name, clone_name).await?;
 
         rmp_serde::from_slice(
             self.zome_call_raw_cell_id(cell_id, zome_name, fn_name, payload)

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -8,9 +8,9 @@ use holochain_conductor_api::{
     AppAuthenticationRequest, AppInfo, AppRequest, AppResponse, CellInfo, ZomeCall,
 };
 use holochain_keystore::MetaLairClient;
-use holochain_types::prelude::{
-    CellId, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName,
-};
+use holochain_types::{app::CreateCloneCellPayload, prelude::{
+    CellId, ClonedCell, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName
+}};
 use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{collections::HashMap, net::ToSocketAddrs, sync::Arc};
@@ -102,14 +102,50 @@ impl AppConnection {
 
     /// Returns a cell for a given RoleName in a connected app
     pub async fn cell(&mut self, role_name: RoleName) -> Result<CellId> {
-        match &self
-            .cell_info()
-            .await?
+        let info = &self
+        .cell_info()
+        .await?;
+        match &info
             .get(&role_name)
             .ok_or(anyhow!("unable to find cell for RoleName {}!", &role_name))?[0]
         {
             CellInfo::Provisioned(c) => Ok(c.cell_id.clone()),
             _ => Err(anyhow!("unable to find cell for RoleName {}", &role_name)),
+        }
+    }
+
+    /// Returns a all cloned cells for a given RoleName in a connected app
+    pub async fn clone_cells(&mut self, role_name: RoleName) -> Result<Vec<ClonedCell>> {
+        let info = &self
+        .cell_info()
+        .await?;
+        let app_cells = info
+        .get(&role_name)
+        .ok_or(anyhow!("unable to find cells for RoleName {}", &role_name))?;
+        let cells = app_cells.into_iter().filter_map(|cell_info| match cell_info {
+            CellInfo::Cloned(cloned_cell) => Some(cloned_cell.clone()),
+            _ => None
+        }).collect();
+        Ok(cells)
+    }
+
+    /// Returns a cell for a given RoleName and CloneName in a connected app
+    pub async fn clone_cell(&mut self, role_name: RoleName, clone_name: String) -> Result<CellId> {
+        let clone_cells = self.clone_cells(role_name.clone()).await?;
+        let cell = clone_cells.into_iter().find_map(|cell| {
+            if cell.name == clone_name {Some(cell)} else {None}
+        }
+        ).ok_or(anyhow!("unable to find clone cell for RoleName {} with name {}", &role_name, &clone_name))?;
+        Ok(cell.cell_id.clone())
+    }
+    
+    /// Creates a clone cell in a connected app
+    pub async fn create_clone(&mut self, payload: CreateCloneCellPayload) -> Result<ClonedCell> {
+        let app_request = AppRequest::CreateCloneCell(Box::new(payload.clone()));
+        let response = self.send(app_request).await?;
+        match response {
+            AppResponse::CloneCellCreated(cell) => Ok(cell),
+            _ => Err(anyhow!("Error creating clone {:?}", payload)),
         }
     }
 
@@ -136,16 +172,29 @@ impl AppConnection {
         fn_name: FunctionName,
         payload: T,
     ) -> Result<ExternIO> {
+
+        let cell_id = self.cell(role_name).await?;
+        self.zome_call_raw_cell_id(cell_id, zome_name, fn_name, payload).await
+    }
+
+    /// Make a zome call to holochain's cell defined by `cell_id``.
+    /// Returns raw response in a form of ExternIo encoded bytes
+    pub async fn zome_call_raw_cell_id<T: Debug + Serialize>(
+        &mut self,
+        cell_id: CellId,
+        zome_name: ZomeName,
+        fn_name: FunctionName,
+        payload: T,
+    ) -> Result<ExternIO> {
         let (nonce, expires_at) = fresh_nonce()?;
-        let cell = self.cell(role_name).await?;
 
         let zome_call_unsigned = ZomeCallUnsigned {
-            cell_id: cell.clone(),
+            cell_id: cell_id.clone(),
             zome_name,
             fn_name,
             payload: ExternIO::encode(payload)?,
             cap_secret: None,
-            provenance: cell.agent_pubkey().clone(),
+            provenance: cell_id.agent_pubkey().clone(),
             nonce,
             expires_at,
         };
@@ -172,8 +221,34 @@ impl AppConnection {
         T: Serialize + Debug,
         R: DeserializeOwned,
     {
+
         rmp_serde::from_slice(
             self.zome_call_raw(role_name, zome_name, fn_name, payload)
+                .await?
+                .as_bytes(),
+        )
+        .context("Error while deserializing zome call response")
+    }
+
+    /// Make a zome call to holochain's cell defined by `role_id` and `clone_name`.
+    /// Returns typed deserialized response.
+    pub async fn clone_zome_call_typed<T, R>(
+        &mut self,
+        role_name: RoleName,
+        clone_name: String,
+        zome_name: ZomeName,
+        fn_name: FunctionName,
+        payload: T,
+    ) -> Result<R>
+    where
+        T: Serialize + Debug,
+        R: DeserializeOwned,
+    {
+
+        let cell_id = self.clone_cell(role_name, clone_name).await?;
+
+        rmp_serde::from_slice(
+            self.zome_call_raw_cell_id(cell_id, zome_name, fn_name, payload)
                 .await?
                 .as_bytes(),
         )

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -8,9 +8,10 @@ use holochain_conductor_api::{
     AppAuthenticationRequest, AppInfo, AppRequest, AppResponse, CellInfo, ZomeCall,
 };
 use holochain_keystore::MetaLairClient;
-use holochain_types::{app::CreateCloneCellPayload, prelude::{
-    CellId, ClonedCell, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName
-}};
+use holochain_types::{
+    app::CreateCloneCellPayload,
+    prelude::{CellId, ClonedCell, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName},
+};
 use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
 use serde::{de::DeserializeOwned, Serialize};
 use std::{collections::HashMap, net::ToSocketAddrs, sync::Arc};
@@ -102,9 +103,7 @@ impl AppConnection {
 
     /// Returns a cell for a given RoleName in a connected app
     pub async fn cell(&mut self, role_name: RoleName) -> Result<CellId> {
-        let info = &self
-        .cell_info()
-        .await?;
+        let info = &self.cell_info().await?;
         match &info
             .get(&role_name)
             .ok_or(anyhow!("unable to find cell for RoleName {}!", &role_name))?[0]
@@ -116,29 +115,40 @@ impl AppConnection {
 
     /// Returns a all cloned cells for a given RoleName in a connected app
     pub async fn clone_cells(&mut self, role_name: RoleName) -> Result<Vec<ClonedCell>> {
-        let info = &self
-        .cell_info()
-        .await?;
+        let info = &self.cell_info().await?;
         let app_cells = info
-        .get(&role_name)
-        .ok_or(anyhow!("unable to find cells for RoleName {}", &role_name))?;
-        let cells = app_cells.into_iter().filter_map(|cell_info| match cell_info {
-            CellInfo::Cloned(cloned_cell) => Some(cloned_cell.clone()),
-            _ => None
-        }).collect();
+            .get(&role_name)
+            .ok_or(anyhow!("unable to find cells for RoleName {}", &role_name))?;
+        let cells = app_cells
+            .into_iter()
+            .filter_map(|cell_info| match cell_info {
+                CellInfo::Cloned(cloned_cell) => Some(cloned_cell.clone()),
+                _ => None,
+            })
+            .collect();
         Ok(cells)
     }
 
     /// Returns a cell for a given RoleName and CloneName in a connected app
     pub async fn clone_cell(&mut self, role_name: RoleName, clone_name: String) -> Result<CellId> {
         let clone_cells = self.clone_cells(role_name.clone()).await?;
-        let cell = clone_cells.into_iter().find_map(|cell| {
-            if cell.name == clone_name {Some(cell)} else {None}
-        }
-        ).ok_or(anyhow!("unable to find clone cell for RoleName {} with name {}", &role_name, &clone_name))?;
+        let cell = clone_cells
+            .into_iter()
+            .find_map(|cell| {
+                if cell.name == clone_name {
+                    Some(cell)
+                } else {
+                    None
+                }
+            })
+            .ok_or(anyhow!(
+                "unable to find clone cell for RoleName {} with name {}",
+                &role_name,
+                &clone_name
+            ))?;
         Ok(cell.cell_id.clone())
     }
-    
+
     /// Creates a clone cell in a connected app
     pub async fn create_clone(&mut self, payload: CreateCloneCellPayload) -> Result<ClonedCell> {
         let app_request = AppRequest::CreateCloneCell(Box::new(payload.clone()));
@@ -172,9 +182,9 @@ impl AppConnection {
         fn_name: FunctionName,
         payload: T,
     ) -> Result<ExternIO> {
-
         let cell_id = self.cell(role_name).await?;
-        self.zome_call_raw_cell_id(cell_id, zome_name, fn_name, payload).await
+        self.zome_call_raw_cell_id(cell_id, zome_name, fn_name, payload)
+            .await
     }
 
     /// Make a zome call to holochain's cell defined by `cell_id``.
@@ -221,7 +231,6 @@ impl AppConnection {
         T: Serialize + Debug,
         R: DeserializeOwned,
     {
-
         rmp_serde::from_slice(
             self.zome_call_raw(role_name, zome_name, fn_name, payload)
                 .await?
@@ -244,7 +253,6 @@ impl AppConnection {
         T: Serialize + Debug,
         R: DeserializeOwned,
     {
-
         let cell_id = self.clone_cell(role_name, clone_name).await?;
 
         rmp_serde::from_slice(

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -9,8 +9,14 @@ use holochain_conductor_api::{
 };
 use holochain_keystore::MetaLairClient;
 use holochain_types::{
-    app::{CreateCloneCellPayload, DeleteCloneCellPayload, DisableCloneCellPayload, EnableCloneCellPayload},
-    prelude::{CellId, ClonedCell, EnableCloneCellInput, ExternIO, FunctionName, RoleName, ZomeCallUnsigned, ZomeName},
+    app::{
+        CreateCloneCellPayload, DeleteCloneCellPayload, DisableCloneCellPayload,
+        EnableCloneCellPayload,
+    },
+    prelude::{
+        CellId, ClonedCell, EnableCloneCellInput, ExternIO, FunctionName, RoleName,
+        ZomeCallUnsigned, ZomeName,
+    },
 };
 use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
 use serde::{de::DeserializeOwned, Serialize};
@@ -162,7 +168,7 @@ impl AppConnection {
     /// Disables a clone cell
     pub async fn disable_clone(&mut self, payload: DisableCloneCellPayload) -> Result<()> {
         let app_request = AppRequest::DisableCloneCell(Box::new(payload.clone()));
-        let response = self.send(app_request,).await?;
+        let response = self.send(app_request).await?;
         match response {
             AppResponse::CloneCellDisabled => Ok(()),
             _ => Err(anyhow!("Error disabling clone {:?}", payload)),
@@ -172,13 +178,13 @@ impl AppConnection {
     /// Enable a clone cell
     pub async fn enable_clone(&mut self, payload: EnableCloneCellPayload) -> Result<ClonedCell> {
         let app_request = AppRequest::EnableCloneCell(Box::new(payload.clone()));
-        let response = self.send(app_request,).await?;
+        let response = self.send(app_request).await?;
         match response {
             AppResponse::CloneCellEnabled(cloned_cell) => Ok(cloned_cell),
             _ => Err(anyhow!("Error enabling clone {:?}", payload)),
         }
     }
-    
+
     /// Raw zome call function taking holochain_conductor_api::app_interface::ZomeCall as an argument
     /// and returning AppResponse without checking an outcomeor deserializing
     #[instrument(skip(self))]

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -130,7 +130,11 @@ impl AppConnection {
     }
 
     /// Returns a cell for a given RoleName and CloneName in a connected app
-    pub async fn cloned_cell_id(&mut self, role_name: RoleName, clone_name: String) -> Result<CellId> {
+    pub async fn cloned_cell_id(
+        &mut self,
+        role_name: RoleName,
+        clone_name: String,
+    ) -> Result<CellId> {
         let cloned_cells = self.cloned_cells(role_name.clone()).await?;
         let cell = cloned_cells
             .into_iter()

--- a/crates/hpos_connect_hc/src/lib.rs
+++ b/crates/hpos_connect_hc/src/lib.rs
@@ -42,6 +42,7 @@ pub mod holo_config;
 pub mod holofuel_types;
 pub mod hpos_agent;
 pub mod hpos_membrane_proof;
+pub mod sl_utils;
 pub mod utils;
 pub use admin_ws::AdminWebsocket;
 pub use app_connection::AppConnection;

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -7,6 +7,7 @@ use chrono::Timelike;
 use chrono::Utc;
 use const_env::from_env;
 use holochain_types::prelude::ClonedCell;
+use anyhow::{anyhow, Result};
 
 // General Notes:
 // These constants are defined here for use by all the other repos
@@ -95,4 +96,22 @@ pub fn sl_within_deleting_check_window(window_size: u32) -> bool {
     let now = Local::now();
     let min = now.minute();
     now.hour() == 0 && min >= 1 && min <= window_size
+}
+
+/// creates the clone name from the bucket and bucket size
+pub fn sl_clone_name(spec: SlCloneSpec) -> String {
+    format!("{}.{}", spec.days_in_bucket, spec.time_bucket)
+}
+
+pub struct SlCloneSpec {
+    pub days_in_bucket: u32, 
+    pub time_bucket: u32,
+}
+
+/// returns the bucket size and bucket from a clone name
+pub fn sl_clone_name_spec(name: &str) -> Result<SlCloneSpec> {
+    let mut parts = name.split(".");
+    let days_in_bucket = parts.next().ok_or(anyhow!("no days in clone name"))?.parse::<u32>()?;
+    let time_bucket = parts.next().ok_or(anyhow!("no bucket in clone name"))?.parse::<u32>()?;
+    Ok(SlCloneSpec{days_in_bucket, time_bucket})
 }

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -6,11 +6,17 @@ use chrono::NaiveDate;
 use chrono::Timelike;
 use chrono::Utc;
 use holochain_types::prelude::ClonedCell;
+use const_env::from_env;
 
+#[from_env]
 pub const SL_BUCKET_SIZE_DAYS: u32 = 14;
+#[from_env]
 pub const SL_MINUTES_BEFORE_BUCKET_TO_CLONE: i64 = 9;
-pub const SL_DELETING_LOG_WINDOW_SIZE_MIN: u32 = 10;
+#[from_env]
+pub const SL_DELETING_LOG_WINDOW_SIZE_MINUTES: u32 = 10;
+#[from_env]
 pub const HOLO_EPOCH_YEAR: u16 = 2024;
+
 
 /// given the date in UTC timezone, return the current bucket
 pub fn time_bucket_from_date(date: DateTime<Utc>, days_in_bucket: u32) -> u32 {

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -1,3 +1,4 @@
+use anyhow::{anyhow, Result};
 use chrono::DateTime;
 use chrono::Datelike;
 use chrono::Duration;
@@ -7,14 +8,13 @@ use chrono::Timelike;
 use chrono::Utc;
 use const_env::from_env;
 use holochain_types::prelude::ClonedCell;
-use anyhow::{anyhow, Result};
 
 // General Notes:
 // These constants are defined here for use by all the other repos
 // that depend on service-logger function.  They should only be overridden
 // globally in holo-nixpkgs if the system wide determination is made to
 // change the default values.
-// The primary place that uses these values is hpos-api-rust, but other 
+// The primary place that uses these values is hpos-api-rust, but other
 // repos may also consume them.
 
 // Time-bucket Notes:
@@ -104,14 +104,23 @@ pub fn sl_clone_name(spec: SlCloneSpec) -> String {
 }
 
 pub struct SlCloneSpec {
-    pub days_in_bucket: u32, 
+    pub days_in_bucket: u32,
     pub time_bucket: u32,
 }
 
 /// returns the bucket size and bucket from a clone name
 pub fn sl_clone_name_spec(name: &str) -> Result<SlCloneSpec> {
     let mut parts = name.split(".");
-    let days_in_bucket = parts.next().ok_or(anyhow!("no days in clone name"))?.parse::<u32>()?;
-    let time_bucket = parts.next().ok_or(anyhow!("no bucket in clone name"))?.parse::<u32>()?;
-    Ok(SlCloneSpec{days_in_bucket, time_bucket})
+    let days_in_bucket = parts
+        .next()
+        .ok_or(anyhow!("no days in clone name"))?
+        .parse::<u32>()?;
+    let time_bucket = parts
+        .next()
+        .ok_or(anyhow!("no bucket in clone name"))?
+        .parse::<u32>()?;
+    Ok(SlCloneSpec {
+        days_in_bucket,
+        time_bucket,
+    })
 }

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -7,7 +7,7 @@ use chrono::NaiveDate;
 use chrono::Timelike;
 use chrono::Utc;
 use const_env::from_env;
-use holochain_types::dna::{ActionHashB64, AgentPubKey, DnaHashB64};
+use holochain_types::dna::{ActionHashB64, AgentPubKeyB64, DnaHashB64};
 use holochain_types::prelude::YamlProperties;
 use holochain_types::prelude::{holochain_serial, SerializedBytes};
 use serde::Deserialize;
@@ -45,7 +45,7 @@ pub struct SlDnaProperties {
     pub bound_happ_id: Option<ActionHashB64>,
     pub bound_hf_dna: Option<DnaHashB64>,
     pub bound_hha_dna: Option<DnaHashB64>,
-    pub holo_admin: Option<AgentPubKey>,
+    pub holo_admin: Option<AgentPubKeyB64>,
     pub bucket_size: Option<u32>,
     pub time_bucket: Option<u32>,
 }

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -79,11 +79,10 @@ pub fn sl_within_min_of_next_time_bucket(days_in_bucket: u32, minutes_before: i6
 }
 
 /// returns all the buckets that are inside the range of the `days` param
-pub fn sl_get_bucket_range(_clone_cells: Vec<ClonedCell>, days: u32) -> (u32, u32, u32) {
-    let bucket_size = SL_BUCKET_SIZE_DAYS; // TODO: get this from: clone_cells[0].dna_modifiers.properties;
+pub fn sl_get_bucket_range(bucket_size: u32, days: u32) -> (u32, u32) {
     let time_bucket: u32 = sl_get_current_time_bucket(bucket_size);
     let buckets_for_days_in_request = days / bucket_size;
-    (bucket_size, time_bucket, buckets_for_days_in_request)
+    (time_bucket, buckets_for_days_in_request)
 }
 
 /// returns whether the local time is within the deleting window which is`windows_size`` min after midnight.

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -9,7 +9,7 @@ use holochain_types::prelude::ClonedCell;
 
 pub const SL_BUCKET_SIZE_DAYS: u32 = 14;
 pub const SL_MINUTES_BEFORE_BUCKET_TO_CLONE: i64 = 9;
-pub const SL_DELETING_LOG_WINDOW_SIZE_MIN : u32 = 10;
+pub const SL_DELETING_LOG_WINDOW_SIZE_MIN: u32 = 10;
 pub const HOLO_EPOCH_YEAR: u16 = 2024;
 
 /// given the date in UTC timezone, return the current bucket
@@ -71,5 +71,5 @@ pub fn sl_within_deleting_check_window(window_size: u32) -> bool {
     }
     let now = Local::now();
     let min = now.minute();
-    now.hour() == 0 && min >=1 && min <=window_size
+    now.hour() == 0 && min >= 1 && min <= window_size
 }

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -51,9 +51,7 @@ pub struct SlDnaProperties {
 }
 
 pub fn sl_serialized_props(props: &SlDnaProperties) -> YamlProperties {
-    YamlProperties::new(
-        serde_yaml::to_value(props)
-        .expect("should serialize"))
+    YamlProperties::new(serde_yaml::to_value(props).expect("should serialize"))
 }
 
 /// given the date in UTC timezone, return the current bucket

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -27,7 +27,7 @@ pub fn time_bucket_from_date(date: DateTime<Utc>, days_in_bucket: u32) -> u32 {
 }
 
 /// returns the current time bucket in a deterministic way so that all code elements
-/// that rely on logging can know which service logger instance they should be
+/// that rely on logging can know the service logger instance with which they should be
 /// interacting
 pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
     let now_utc = Utc::now();
@@ -45,7 +45,7 @@ pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
 }
 
 /// returns whether we are within `minutes_before` minutes of the next time bucket
-/// (used to check for cloning new service loggers)
+/// (this fn is used to check for cloning new service loggers)
 pub fn sl_within_min_of_next_time_bucket(days_in_bucket: u32, minutes_before: i64) -> bool {
     if let Ok(val) = std::env::var("SL_TEST_IS_BEFORE_NEXT_BUCKET") {
         if val == "true" {
@@ -59,7 +59,7 @@ pub fn sl_within_min_of_next_time_bucket(days_in_bucket: u32, minutes_before: i6
     current_time_bucket != time_bucket_soon
 }
 
-/// returns all the buckets that are indide the range of the `days` param
+/// returns all the buckets that are inside the range of the `days` param
 pub fn sl_get_bucket_range(_clone_cells: Vec<ClonedCell>, days: u32) -> (u32, u32, u32) {
     let bucket_size = SL_BUCKET_SIZE_DAYS; // TODO: get this from: clone_cells[0].dna_modifiers.properties;
     let time_bucket: u32 = sl_get_current_time_bucket(bucket_size);

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -1,23 +1,46 @@
+use chrono::DateTime;
 use chrono::Datelike;
 use chrono::NaiveDate;
+use chrono::Duration;
 use chrono::Timelike;
 use chrono::Utc;
 use holochain_types::prelude::ClonedCell;
 
 pub const SL_BUCKET_SIZE_DAYS: u32 = 14;
+pub const SL_MINUTES_BEFORE_BUCKET_TO_CLONE: i64 = 9;
 pub const HOLO_EPOCH_YEAR: u16 = 2024;
+
+pub fn time_bucket_from_date(date: DateTime<Utc>, days_in_bucket: u32) -> u32 {
+    let epoch_start = NaiveDate::from_ymd_opt(HOLO_EPOCH_YEAR.into(), 1, 1).unwrap();
+    let days_since_epoch: u32 = (date.num_days_from_ce() - epoch_start.num_days_from_ce())
+        .try_into()
+        .expect("now should always be after Holo epoch");
+    days_since_epoch / days_in_bucket
+}
 
 pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
     let now_utc = Utc::now();
     if std::env::var("IS_TEST_ENV").is_ok() {
-        10
+        if let Ok(test_time_bucket_str) = std::env::var("SL_TEST_TIME_BUCKET") {
+            test_time_bucket_str.parse::<u32>().expect("wanted an int for SL_TEST_TIME_BUCKET")
+        } else {
+            10
+        }
     } else {
-        let epoch_start = NaiveDate::from_ymd_opt(HOLO_EPOCH_YEAR.into(), 1, 1).unwrap();
-        let days_since_epoch: u32 = (now_utc.num_days_from_ce() - epoch_start.num_days_from_ce())
-            .try_into()
-            .expect("now should always be after Holo epoch");
-        days_since_epoch / days_in_bucket
+        time_bucket_from_date(now_utc, days_in_bucket)
     }
+}
+
+pub fn sl_within_min_of_next_time_bucket(days_in_bucket: u32, minutes_before: i64) -> bool {
+    if let Ok(val) = std::env::var("SL_TEST_IS_BEFORE_NEXT_BUCKET") {
+         if val == "true" {
+            return true;
+         }
+    }
+    let now_utc = Utc::now();
+    let current_time_bucket = time_bucket_from_date(now_utc, days_in_bucket);
+    let time_bucket_soon = time_bucket_from_date(now_utc + Duration::minutes(minutes_before), days_in_bucket);
+    current_time_bucket != time_bucket_soon
 }
 
 pub fn sl_get_bucket_range(_clone_cells: Vec<ClonedCell>, days: u32) -> (u32, u32, u32) {

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -1,7 +1,7 @@
 use chrono::Datelike;
 use chrono::NaiveDate;
-use chrono::Utc;
 use chrono::Timelike;
+use chrono::Utc;
 use holochain_types::prelude::ClonedCell;
 
 pub const SL_BUCKET_SIZE_DAYS: u32 = 14;
@@ -13,15 +13,16 @@ pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
         10
     } else {
         let epoch_start = NaiveDate::from_ymd_opt(HOLO_EPOCH_YEAR.into(), 1, 1).unwrap();
-        let days_since_epoch : u32 = (now_utc.num_days_from_ce()-epoch_start.num_days_from_ce()).try_into().expect("now should always be after Holo epoch");
-        days_since_epoch/days_in_bucket
+        let days_since_epoch: u32 = (now_utc.num_days_from_ce() - epoch_start.num_days_from_ce())
+            .try_into()
+            .expect("now should always be after Holo epoch");
+        days_since_epoch / days_in_bucket
     }
 }
 
-
-pub fn sl_get_bucket_range(_clone_cells: Vec<ClonedCell>, days: u32) -> (u32, u32, u32){
+pub fn sl_get_bucket_range(_clone_cells: Vec<ClonedCell>, days: u32) -> (u32, u32, u32) {
     let bucket_size = SL_BUCKET_SIZE_DAYS; // TODO: get this from: clone_cells[0].dna_modifiers.properties;
     let time_bucket: u32 = sl_get_current_time_bucket(bucket_size);
-    let buckets_for_days_in_request = days/bucket_size;
+    let buckets_for_days_in_request = days / bucket_size;
     (bucket_size, time_bucket, buckets_for_days_in_request)
 }

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -5,8 +5,8 @@ use chrono::Local;
 use chrono::NaiveDate;
 use chrono::Timelike;
 use chrono::Utc;
-use holochain_types::prelude::ClonedCell;
 use const_env::from_env;
+use holochain_types::prelude::ClonedCell;
 
 #[from_env]
 pub const SL_BUCKET_SIZE_DAYS: u32 = 14;
@@ -16,7 +16,6 @@ pub const SL_MINUTES_BEFORE_BUCKET_TO_CLONE: i64 = 9;
 pub const SL_DELETING_LOG_WINDOW_SIZE_MINUTES: u32 = 10;
 #[from_env]
 pub const HOLO_EPOCH_YEAR: u16 = 2024;
-
 
 /// given the date in UTC timezone, return the current bucket
 pub fn time_bucket_from_date(date: DateTime<Utc>, days_in_bucket: u32) -> u32 {

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -1,0 +1,27 @@
+use chrono::Datelike;
+use chrono::NaiveDate;
+use chrono::Utc;
+use chrono::Timelike;
+use holochain_types::prelude::ClonedCell;
+
+pub const SL_BUCKET_SIZE_DAYS: u32 = 14;
+pub const HOLO_EPOCH_YEAR: u16 = 2024;
+
+pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
+    let now_utc = Utc::now();
+    if std::env::var("IS_TEST_ENV").is_ok() {
+        10
+    } else {
+        let epoch_start = NaiveDate::from_ymd_opt(HOLO_EPOCH_YEAR.into(), 1, 1).unwrap();
+        let days_since_epoch : u32 = (now_utc.num_days_from_ce()-epoch_start.num_days_from_ce()).try_into().expect("now should always be after Holo epoch");
+        days_since_epoch/days_in_bucket
+    }
+}
+
+
+pub fn sl_get_bucket_range(_clone_cells: Vec<ClonedCell>, days: u32) -> (u32, u32, u32){
+    let bucket_size = SL_BUCKET_SIZE_DAYS; // TODO: get this from: clone_cells[0].dna_modifiers.properties;
+    let time_bucket: u32 = sl_get_current_time_bucket(bucket_size);
+    let buckets_for_days_in_request = days/bucket_size;
+    (bucket_size, time_bucket, buckets_for_days_in_request)
+}

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -1,7 +1,7 @@
 use chrono::DateTime;
 use chrono::Datelike;
-use chrono::NaiveDate;
 use chrono::Duration;
+use chrono::NaiveDate;
 use chrono::Timelike;
 use chrono::Utc;
 use holochain_types::prelude::ClonedCell;
@@ -22,7 +22,9 @@ pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
     let now_utc = Utc::now();
     if std::env::var("IS_TEST_ENV").is_ok() {
         if let Ok(test_time_bucket_str) = std::env::var("SL_TEST_TIME_BUCKET") {
-            test_time_bucket_str.parse::<u32>().expect("wanted an int for SL_TEST_TIME_BUCKET")
+            test_time_bucket_str
+                .parse::<u32>()
+                .expect("wanted an int for SL_TEST_TIME_BUCKET")
         } else {
             10
         }
@@ -33,13 +35,14 @@ pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
 
 pub fn sl_within_min_of_next_time_bucket(days_in_bucket: u32, minutes_before: i64) -> bool {
     if let Ok(val) = std::env::var("SL_TEST_IS_BEFORE_NEXT_BUCKET") {
-         if val == "true" {
+        if val == "true" {
             return true;
-         }
+        }
     }
     let now_utc = Utc::now();
     let current_time_bucket = time_bucket_from_date(now_utc, days_in_bucket);
-    let time_bucket_soon = time_bucket_from_date(now_utc + Duration::minutes(minutes_before), days_in_bucket);
+    let time_bucket_soon =
+        time_bucket_from_date(now_utc + Duration::minutes(minutes_before), days_in_bucket);
     current_time_bucket != time_bucket_soon
 }
 

--- a/crates/hpos_connect_hc/src/sl_utils.rs
+++ b/crates/hpos_connect_hc/src/sl_utils.rs
@@ -8,6 +8,21 @@ use chrono::Utc;
 use const_env::from_env;
 use holochain_types::prelude::ClonedCell;
 
+// General Notes:
+// These constants are defined here for use by all the other repos
+// that depend on service-logger function.  They should only be overridden
+// globally in holo-nixpkgs if the system wide determination is made to
+// change the default values.
+// The primary place that uses these values is hpos-api-rust, but other 
+// repos may also consume them.
+
+// Time-bucket Notes:
+// Currently the time-bucket size (SL_BUCKET_SIZE_DAYS) is a implemented as a global constant,
+// that should apply for all service-logger instances, the sl-dna is built to be future-proofed
+// and thus stores the value in its properties.  This is so that different apps could have different
+// log rotation schedules.  But that is not currently implemented in the `sl-check` endpoint of
+// `hpos-api-rust`.  But this is why all of these functions take the `days_in_bucket`` parameter
+// rather than using the global directly.
 #[from_env]
 pub const SL_BUCKET_SIZE_DAYS: u32 = 14;
 #[from_env]
@@ -46,6 +61,9 @@ pub fn sl_get_current_time_bucket(days_in_bucket: u32) -> u32 {
 
 /// returns whether we are within `minutes_before` minutes of the next time bucket
 /// (this fn is used to check for cloning new service loggers)
+/// note that `days_in_bucket` and `minutes_before` are passed in as parameters by
+/// the caller as part of future-proofing, but currently they all just use the constants
+/// provided above.
 pub fn sl_within_min_of_next_time_bucket(days_in_bucket: u32, minutes_before: i64) -> bool {
     if let Ok(val) = std::env::var("SL_TEST_IS_BEFORE_NEXT_BUCKET") {
         if val == "true" {

--- a/flake.lock
+++ b/flake.lock
@@ -172,11 +172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720108358,
-        "narHash": "sha256-gXhphrxVUfIIht9iR0DD1UWu/XwMrC+3LLsTvBBA5pQ=",
+        "lastModified": 1720125457,
+        "narHash": "sha256-FFUg2nnXEXwePi+Y2uL8CATjeWALqRIF3Je1WYCm430=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "01570f0e096fa18f0cca9db63b618edf7e566293",
+        "rev": "3297a053c39db9c2c37794b6219b8857320d97d4",
         "type": "github"
       },
       "original": {
@@ -356,11 +356,11 @@
       },
       "locked": {
         "dir": "versions/weekly",
-        "lastModified": 1720108358,
-        "narHash": "sha256-gXhphrxVUfIIht9iR0DD1UWu/XwMrC+3LLsTvBBA5pQ=",
+        "lastModified": 1720125457,
+        "narHash": "sha256-FFUg2nnXEXwePi+Y2uL8CATjeWALqRIF3Je1WYCm430=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "01570f0e096fa18f0cca9db63b618edf7e566293",
+        "rev": "3297a053c39db9c2c37794b6219b8857320d97d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates `AppConnection` with:

- method to create a clone cell in a connected app
- method to make zome calls in a cloned cell specified by clone name
- method to return all clone_cells in a connected app
- utils for calculating the current service-logger time-bucket
 