### PR TITLE
special_installed_app_id: for holofuel

### DIFF
--- a/crates/holo_happ_manager/src/lib.rs
+++ b/crates/holo_happ_manager/src/lib.rs
@@ -30,8 +30,8 @@ pub async fn run(config: &Config) -> Result<()> {
         {
             // Check if the name is "cloud console"
             // if it does set a special_installed_app_id as the installed_app_id of the core_app
-            // This special_installed_app_id is designed for Cloud Console(formally know as Publisher Portal)
-            if app.name.contains("Cloud") {
+            // This special_installed_app_id is designed for Cloud Console or Holofuel
+            if app.name.contains("Cloud") || app.name.contains("Holofuel") {
                 app.special_installed_app_id = Some(hha.id())
             }
             hha.publish_happ(app).await?;


### PR DESCRIPTION
This is because the Holofuel app is not going to be installed because it will error with `CellAlreadyInstalled` . 

And so with the updated implementation of the /install endpoint on host we don't want to handle the case such that it  enables the app even thought there is not anonymous agent installed.

This update will clean up that assumption.