### PR TITLE
Fix/Avoid duplicate app interface creation + clean-up

### DIFF
--- a/crates/configure-holochain/src/jurisdictions.rs
+++ b/crates/configure-holochain/src/jurisdictions.rs
@@ -3,7 +3,9 @@ use holochain_types::{
     dna::AgentPubKey,
     prelude::{FunctionName, ZomeName},
 };
-use hpos_hc_connect::{app_connection::CoreAppRoleName, hha_agent::HHAAgent, holo_config::Config};
+use hpos_hc_connect::{
+    app_connection::CoreAppRoleName, hha_agent::CoreAppAgent, holo_config::Config,
+};
 use serde::{Deserialize, Serialize};
 use std::process::{Command, Output};
 
@@ -31,7 +33,7 @@ pub async fn update_jurisdiction_if_changed(
     config: &Config,
     hbs_jurisdiction: String,
 ) -> Result<()> {
-    let mut agent = HHAAgent::spawn(Some(config)).await?;
+    let mut agent = CoreAppAgent::spawn(Some(config)).await?;
 
     let host_pubkey = agent.pubkey().await?;
 

--- a/crates/configure-holochain/src/lib.rs
+++ b/crates/configure-holochain/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn install_happs(happ_file: &HappsFile, config: &Config) -> Result<()>
         .context("failed to connect to holochain's admin interface")?;
 
     if let Err(error) = admin_websocket
-        .attach_app_interface(Some(config.happ_port))
+        .attach_app_interface(Some(config.happ_port), None)
         .await
     {
         warn!(port = ?config.happ_port, ?error, "failed to start app interface for hosted happs, maybe it's already up?");

--- a/crates/configure-holochain/tests/integration.rs
+++ b/crates/configure-holochain/tests/integration.rs
@@ -53,8 +53,8 @@ use test_case::test_case;
 /// Tests cannot run in parallel because they are all accessing same /tmp dir
 
 async fn run_configure_holochain(f_r_a_k: &str, r_o_m_p: &str) {
-    // Uncomment those lines if you need logging
-    // but this will work only for one test case ran at the time
+    // Uncomment these lines if you need logging
+    // but this will work only for one test case run at the time
     // because tracing subscribes here sets a global subscriber for each test
     // use tracing_subscriber::EnvFilter;
     // let filter = EnvFilter::from_default_env().add_directive("again=trace".parse().unwrap());
@@ -84,7 +84,7 @@ async fn run_configure_holochain(f_r_a_k: &str, r_o_m_p: &str) {
     // Holoports do not force read-only memproof
     set_var("READ_ONLY_MEM_PROOF", r_o_m_p);
 
-    // devNet HBS server url, because given hpos-config is registered in devNet database
+    // Use devNet HBS server url, because given hpos-config is registered in devNet database
     set_var(
         "MEM_PROOF_SERVER_URL",
         "https://membrane-proof.dev.holotest.net",
@@ -100,7 +100,7 @@ async fn run_configure_holochain(f_r_a_k: &str, r_o_m_p: &str) {
     };
 
     // spin up lair
-    println!("Starting lair-keystore");
+    println!("\nStarting lair-keystore");
     let (_lair, lair_config, _) =
         holochain_env_setup::lair::spawn(&tmp_dir, &log_dir, Some(&device_bundle), None)
             .await
@@ -125,17 +125,23 @@ async fn run_configure_holochain(f_r_a_k: &str, r_o_m_p: &str) {
     set_var("IS_INTEGRATION_TEST", "TRUE");
 
     println!("Run configure holochain script");
-    configure_holochain::run(config.clone()).await.unwrap();
+    configure_holochain::run(config.clone())
+        .await
+        .expect("Failed when running configure holochain script the first time");
 
     // Second run should not error out
-    configure_holochain::run(config.clone()).await.unwrap();
+    configure_holochain::run(config.clone())
+        .await
+        .expect("Failed when running configure holochain script the second time");
 
     // Delete memproof which is an equivalent of changing DEV_UID_OVERRIDE for holoport
     // which was creating a bug https://github.com/Holo-Host/hpos-configure-holochain/issues/136
     delete_mem_proof_file().unwrap();
 
     // Third run should not error out
-    configure_holochain::run(config).await.unwrap();
+    configure_holochain::run(config)
+        .await
+        .expect("Failed when running configure holochain script the third time");
 
     let mut connection = configure_holochain::AdminWebsocket::connect(4444)
         .await

--- a/crates/core_app_cli/src/actions/enable_happ_for_host.rs
+++ b/crates/core_app_cli/src/actions/enable_happ_for_host.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 use holochain_types::prelude::ActionHashB64;
 use holochain_types::prelude::{FunctionName, ZomeName};
 use hpos_hc_connect::app_connection::CoreAppRoleName;
-use hpos_hc_connect::hha_agent::HHAAgent;
+use hpos_hc_connect::hha_agent::CoreAppAgent;
 use hpos_hc_connect::hha_types::HappAndHost;
 
 pub async fn get(happ_id: String, host_id: String) -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let holo_hash = ActionHashB64::from_b64_str(&happ_id.clone())
         .expect("Failed to serialize string into ActionHashB4");

--- a/crates/core_app_cli/src/actions/get_happ_hosts.rs
+++ b/crates/core_app_cli/src/actions/get_happ_hosts.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use holochain_types::prelude::{FunctionName, ZomeName};
 use hpos_hc_connect::{
-    app_connection::CoreAppRoleName, hha_agent::HHAAgent, hha_types::HoloportDetails,
+    app_connection::CoreAppRoleName, hha_agent::CoreAppAgent, hha_types::HoloportDetails,
 };
 
 pub async fn get(happ_id: String) -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let hosts: Vec<HoloportDetails> = agent
         .app

--- a/crates/core_app_cli/src/actions/get_happ_pref_for_host.rs
+++ b/crates/core_app_cli/src/actions/get_happ_pref_for_host.rs
@@ -3,11 +3,11 @@
 use anyhow::Result;
 use holochain_types::prelude::{FunctionName, ZomeName};
 use hpos_hc_connect::{
-    app_connection::CoreAppRoleName, hha_agent::HHAAgent, hha_types::HoloportDetails,
+    app_connection::CoreAppRoleName, hha_agent::CoreAppAgent, hha_types::HoloportDetails,
 };
 
 pub async fn get(happ_id: String, host_id: String) -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let hosts: Vec<HoloportDetails> = agent
         .app

--- a/crates/core_app_cli/src/actions/get_specific_happ_prefs.rs
+++ b/crates/core_app_cli/src/actions/get_specific_happ_prefs.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use holochain_types::prelude::{ActionHash, ActionHashB64, FunctionName, ZomeName};
 use hpos_hc_connect::{
-    app_connection::CoreAppRoleName, hha_agent::HHAAgent, hha_types::HappPreferences,
+    app_connection::CoreAppRoleName, hha_agent::CoreAppAgent, hha_types::HappPreferences,
 };
 
 pub async fn get(pref_hash: String) -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
     let pref_holo_hash = ActionHashB64::from_b64_str(&pref_hash)
         .expect("Failed to serialize string into ActionHashB4");
     let hash = ActionHash::from(pref_holo_hash);

--- a/crates/core_app_cli/src/actions/ledger.rs
+++ b/crates/core_app_cli/src/actions/ledger.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use holochain_types::prelude::{FunctionName, ZomeName};
 use hpos_hc_connect::app_connection::CoreAppRoleName;
-use hpos_hc_connect::hha_agent::HHAAgent;
+use hpos_hc_connect::hha_agent::CoreAppAgent;
 use hpos_hc_connect::holofuel_types::Ledger;
 
 pub async fn get() -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let ledger: Ledger = agent
         .app

--- a/crates/core_app_cli/src/actions/list_all_my_happs.rs
+++ b/crates/core_app_cli/src/actions/list_all_my_happs.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use holochain_types::prelude::{FunctionName, ZomeName};
 use hpos_hc_connect::{
-    app_connection::CoreAppRoleName, hha_agent::HHAAgent, hha_types::PresentedHappBundle,
+    app_connection::CoreAppRoleName, hha_agent::CoreAppAgent, hha_types::PresentedHappBundle,
 };
 
 pub async fn get() -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let happs: Vec<PresentedHappBundle> = agent
         .app

--- a/crates/core_app_cli/src/actions/list_all_tx.rs
+++ b/crates/core_app_cli/src/actions/list_all_tx.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use holochain_types::prelude::{FunctionName, ZomeName};
 use hpos_hc_connect::{
     app_connection::CoreAppRoleName,
-    hha_agent::HHAAgent,
+    hha_agent::CoreAppAgent,
     holofuel_types::{Actionable, Pending, Transaction},
 };
 
 pub async fn get() -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let txs: Pending = agent
         .app

--- a/crates/core_app_cli/src/actions/pay_invoices.rs
+++ b/crates/core_app_cli/src/actions/pay_invoices.rs
@@ -4,12 +4,12 @@ use holochain_types::prelude::{
     holochain_serial, EntryHashB64, FunctionName, SerializedBytes, ZomeName,
 };
 use hpos_hc_connect::app_connection::CoreAppRoleName;
-use hpos_hc_connect::hha_agent::HHAAgent;
+use hpos_hc_connect::hha_agent::CoreAppAgent;
 use hpos_hc_connect::holofuel_types::Pending;
 use serde::{Deserialize, Serialize};
 
 pub async fn get() -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let txs: Pending = agent
         .app

--- a/crates/core_app_cli/src/actions/profile.rs
+++ b/crates/core_app_cli/src/actions/profile.rs
@@ -1,11 +1,11 @@
 use anyhow::Result;
 use holochain_types::prelude::{FunctionName, ZomeName};
 use hpos_hc_connect::{
-    app_connection::CoreAppRoleName, hha_agent::HHAAgent, holofuel_types::Profile,
+    app_connection::CoreAppRoleName, hha_agent::CoreAppAgent, holofuel_types::Profile,
 };
 
 pub async fn get() -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let profile: Profile = agent
         .app

--- a/crates/core_app_cli/src/actions/set_happ_prefs.rs
+++ b/crates/core_app_cli/src/actions/set_happ_prefs.rs
@@ -3,7 +3,7 @@ use holochain_types::prelude::{ActionHashB64, FunctionName, ZomeName};
 use holofuel_types::fuel::Fuel;
 use hpos_hc_connect::{
     app_connection::CoreAppRoleName,
-    hha_agent::HHAAgent,
+    hha_agent::CoreAppAgent,
     hha_types::{HappPreferences, SetHappPreferencesInput},
 };
 use std::{str::FromStr, time::Duration};
@@ -17,7 +17,7 @@ pub async fn get(
     max_time_before_invoice_sec: String,
     max_time_before_invoice_ms: String,
 ) -> Result<()> {
-    let mut agent = HHAAgent::spawn(None).await?;
+    let mut agent = CoreAppAgent::spawn(None).await?;
 
     let max_time_sec = max_time_before_invoice_sec
         .parse::<u64>()

--- a/crates/holo_happ_manager/src/lib.rs
+++ b/crates/holo_happ_manager/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{env, fs};
 
 use anyhow::{Context, Result};
-use hpos_hc_connect::hha_agent::HHAAgent;
+use hpos_hc_connect::hha_agent::CoreAppAgent;
 pub use hpos_hc_connect::{
     hha_types::HappInput,
     holo_config::{Config, Happ, HappsFile},
@@ -11,7 +11,7 @@ use tracing::{debug, info};
 pub async fn run(config: &Config) -> Result<()> {
     info!("Running happ manager");
 
-    let mut hha = HHAAgent::spawn(Some(config)).await?;
+    let mut hha = CoreAppAgent::spawn(Some(config)).await?;
 
     let apps = happ_to_be_published()?;
 

--- a/crates/holo_happ_manager/tests/integration.rs
+++ b/crates/holo_happ_manager/tests/integration.rs
@@ -1,5 +1,5 @@
 use holo_happ_manager;
-use hpos_hc_connect::hha_agent::HHAAgent;
+use hpos_hc_connect::hha_agent::CoreAppAgent;
 
 #[tokio::test]
 async fn run_happ_manager() {
@@ -83,7 +83,7 @@ async fn run_happ_manager() {
     println!("Run holo happ manager script");
     holo_happ_manager::run(&config).await.unwrap();
 
-    let mut hha = HHAAgent::spawn(Some(&config)).await.unwrap();
+    let mut hha = CoreAppAgent::spawn(Some(&config)).await.unwrap();
 
     let published_happ = hha.get_my_happs().await.unwrap();
 

--- a/crates/hpos_connect_hc/src/admin_ws.rs
+++ b/crates/hpos_connect_hc/src/admin_ws.rs
@@ -6,7 +6,7 @@ use super::hpos_membrane_proof::MembraneProofs;
 use anyhow::{anyhow, Context, Result};
 use holochain_conductor_api::{
     AdminRequest, AdminResponse, AppAuthenticationToken, AppAuthenticationTokenIssued, AppInfo,
-    AppStatusFilter, IssueAppAuthenticationTokenPayload,
+    AppInterfaceInfo, AppStatusFilter, IssueAppAuthenticationTokenPayload,
 };
 use holochain_types::{
     app::{InstallAppPayload, InstalledAppId},
@@ -57,6 +57,14 @@ impl AdminWebsocket {
         match self.send(msg, None).await? {
             AdminResponse::AppInterfaceAttached { port } => Ok(port),
             _ => Err(anyhow!("Failed to attach app interface")),
+        }
+    }
+
+    pub async fn list_app_interfaces(&mut self) -> Result<Vec<AppInterfaceInfo>> {
+        debug!("listing app interfaces");
+        match self.send(AdminRequest::ListAppInterfaces, None).await? {
+            AdminResponse::AppInterfacesListed(app_interfaces) => Ok(app_interfaces),
+            _ => Err(anyhow!("Failed to fetch list of attached app interfaces")),
         }
     }
 

--- a/crates/hpos_connect_hc/src/admin_ws.rs
+++ b/crates/hpos_connect_hc/src/admin_ws.rs
@@ -47,12 +47,16 @@ impl AdminWebsocket {
 
     /// Attach an interface for app calls. If a port numer is None conductor will choose an available port
     /// Returns attached port number
-    pub async fn attach_app_interface(&mut self, happ_port: Option<u16>) -> Result<u16> {
+    pub async fn attach_app_interface(
+        &mut self,
+        happ_port: Option<u16>,
+        installed_app_id: Option<InstalledAppId>,
+    ) -> Result<u16> {
         info!(port = ?happ_port, "starting app interface");
         let msg = AdminRequest::AttachAppInterface {
             port: happ_port,
             allowed_origins: AllowedOrigins::Any,
-            installed_app_id: None,
+            installed_app_id,
         };
         match self.send(msg, None).await? {
             AdminResponse::AppInterfaceAttached { port } => Ok(port),

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -34,29 +34,44 @@ pub struct AppConnection {
 }
 
 impl AppConnection {
+    // Connect to app interface for given installed app id if one already exists,
+    // otherwise attach a new app interface and then establish connection.
     pub async fn connect(
         admin_ws: &mut AdminWebsocket,
         keystore: MetaLairClient,
         app_id: String,
     ) -> Result<Self> {
-        let app_port = admin_ws
-            .attach_app_interface(None)
+        let attached_app_interfaces = admin_ws
+            .list_app_interfaces()
             .await
-            .context("failed to start app interface for core app")?;
+            .context("failed to start fetch app interfaces during app connection setup")?;
+
+        let app_interface = attached_app_interfaces.into_iter().find(|a| {
+            a.installed_app_id.is_some() && a.installed_app_id.to_owned().unwrap() == app_id
+        });
+
+        let app_port = match app_interface {
+            Some(a) => a.port,
+            None => admin_ws
+                .attach_app_interface(None)
+                .await
+                .context("failed to start app interface for core app")?,
+        };
 
         let token = admin_ws.issue_app_auth_token(app_id.clone()).await?;
-
+        let websocket_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
         let socket_addr = format!("localhost:{app_port}");
         let addr = socket_addr
             .to_socket_addrs()?
             .next()
             .context("invalid websocket address")?;
-        let websocket_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
+
         let (tx, rx) = again::retry(|| {
             let websocket_config = Arc::clone(&websocket_config);
             connect(websocket_config, ConnectRequest::new(addr))
         })
         .await?;
+
         let rx = WsPollRecv::new::<AppResponse>(rx).into();
 
         // Websocket connection needs authentication via token previously obtained from Admin Interface

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -49,6 +49,10 @@ impl AppConnection {
         let app_interface = attached_app_interfaces.into_iter().find(|a| {
             a.installed_app_id.is_some() && a.installed_app_id.to_owned().unwrap() == app_id
         });
+        println!(
+            "FOUND APP INTERFACE: >> ?? app_interface: {:?} ",
+            app_interface
+        );
 
         let app_port = match app_interface {
             Some(a) => a.port,
@@ -57,6 +61,8 @@ impl AppConnection {
                 .await
                 .context("failed to start app interface for core app")?,
         };
+
+        println!("USING APP PORT: >> ?? app_port: {} ", app_port);
 
         let token = admin_ws.issue_app_auth_token(app_id.clone()).await?;
         let websocket_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
@@ -78,6 +84,8 @@ impl AppConnection {
         tx.authenticate(AppAuthenticationRequest { token })
             .await
             .map_err(|err| anyhow!("Failed to send authentication: {err:?}"))?;
+
+        println!("CONNECTED TO APP INTEFACE");
 
         Ok(Self {
             ws: AppWebsocket { tx, rx },

--- a/crates/hpos_connect_hc/src/app_connection.rs
+++ b/crates/hpos_connect_hc/src/app_connection.rs
@@ -49,20 +49,14 @@ impl AppConnection {
         let app_interface = attached_app_interfaces.into_iter().find(|a| {
             a.installed_app_id.is_some() && a.installed_app_id.to_owned().unwrap() == app_id
         });
-        println!(
-            "FOUND APP INTERFACE: >> ?? app_interface: {:?} ",
-            app_interface
-        );
 
         let app_port = match app_interface {
             Some(a) => a.port,
             None => admin_ws
-                .attach_app_interface(None)
+                .attach_app_interface(None, Some(app_id.clone()))
                 .await
                 .context("failed to start app interface for core app")?,
         };
-
-        println!("USING APP PORT: >> ?? app_port: {} ", app_port);
 
         let token = admin_ws.issue_app_auth_token(app_id.clone()).await?;
         let websocket_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
@@ -84,8 +78,6 @@ impl AppConnection {
         tx.authenticate(AppAuthenticationRequest { token })
             .await
             .map_err(|err| anyhow!("Failed to send authentication: {err:?}"))?;
-
-        println!("CONNECTED TO APP INTEFACE");
 
         Ok(Self {
             ws: AppWebsocket { tx, rx },

--- a/crates/hpos_connect_hc/src/hf_agent.rs
+++ b/crates/hpos_connect_hc/src/hf_agent.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 /// Struct giving access to local instance of HHA on HPOS
 /// `config` of type `holo_config::Config` represents CLI params and can be passed
 /// to describe local running environment
-#[derive(Clone)]
 pub struct HfAgent {
     pub app: AppConnection,
 }

--- a/crates/hpos_connect_hc/src/hf_agent.rs
+++ b/crates/hpos_connect_hc/src/hf_agent.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 /// Struct giving access to local instance of HHA on HPOS
 /// `config` of type `holo_config::Config` represents CLI params and can be passed
 /// to describe local running environment
+#[derive(Clone)]
 pub struct HfAgent {
     pub app: AppConnection,
 }

--- a/crates/hpos_connect_hc/src/hha_agent.rs
+++ b/crates/hpos_connect_hc/src/hha_agent.rs
@@ -18,11 +18,11 @@ use holochain_types::prelude::{ExternIO, FunctionName, Signature, ZomeName};
 /// `config` of type `holo_config::Config` represents CLI params and can be passed
 /// to describe local running environment
 #[derive(Clone)]
-pub struct HHAAgent {
+pub struct CoreAppAgent {
     pub app: AppConnection,
 }
 
-impl HHAAgent {
+impl CoreAppAgent {
     pub async fn spawn(config: Option<&Config>) -> Result<Self> {
         let mut admin_ws = AdminWebsocket::connect(ADMIN_PORT)
             .await

--- a/crates/hpos_connect_hc/src/hha_agent.rs
+++ b/crates/hpos_connect_hc/src/hha_agent.rs
@@ -17,7 +17,6 @@ use holochain_types::prelude::{ExternIO, FunctionName, Signature, ZomeName};
 /// Struct giving access to local instance of HHA on HPOS
 /// `config` of type `holo_config::Config` represents CLI params and can be passed
 /// to describe local running environment
-#[derive(Clone)]
 pub struct CoreAppAgent {
     pub app: AppConnection,
 }

--- a/crates/hpos_connect_hc/src/hha_agent.rs
+++ b/crates/hpos_connect_hc/src/hha_agent.rs
@@ -17,6 +17,7 @@ use holochain_types::prelude::{ExternIO, FunctionName, Signature, ZomeName};
 /// Struct giving access to local instance of HHA on HPOS
 /// `config` of type `holo_config::Config` represents CLI params and can be passed
 /// to describe local running environment
+#[derive(Clone)]
 pub struct HHAAgent {
     pub app: AppConnection,
 }

--- a/crates/hpos_connect_hc/src/hha_types.rs
+++ b/crates/hpos_connect_hc/src/hha_types.rs
@@ -69,7 +69,7 @@ pub struct SetHappPreferencesInput {
     pub max_time_before_invoice: Duration, // how much time to allow to pass before sending invoice even if fuel trigger not reached.
 }
 
-#[derive(Debug, Serialize, Deserialize, SerializedBytes, Clone)]
+#[derive(Debug, Serialize, Deserialize, SerializedBytes, Clone, Default)]
 pub struct HostSettings {
     is_enabled: bool,
     pub is_host_disabled: bool,

--- a/crates/hpos_connect_hc/src/hpos_membrane_proof.rs
+++ b/crates/hpos_connect_hc/src/hpos_membrane_proof.rs
@@ -81,7 +81,7 @@ pub async fn get_mem_proof(admin: Admin) -> Result<MembraneProof> {
     let memproof_path =
         env::var("MEM_PROOF_PATH").context("Failed to read MEM_PROOF_PATH. Is it set in env?")?;
 
-    println!(
+    debug!(
         "Looking for memproof in provided file at {:?}",
         memproof_path
     );
@@ -89,7 +89,7 @@ pub async fn get_mem_proof(admin: Admin) -> Result<MembraneProof> {
         debug!("Using memproof from file");
         return Ok(m);
     }
-    println!("No Membrane Proof found locally.");
+    debug!("No Membrane Proof found locally.");
 
     let role = env::var("HOLOFUEL_INSTANCE_ROLE")
         .context("Failed to read HOLOFUEL_INSTANCE_ROLE. Is it set in env?")?;
@@ -100,10 +100,10 @@ pub async fn get_mem_proof(admin: Admin) -> Result<MembraneProof> {
         payload: RegistrationPayload { role },
     };
 
-    println!("Getting memproof from Membrane Proof server...");
+    debug!("Getting memproof from Membrane Proof server...");
     let (mem_proof_str, mem_proof_serialized) = download_memproof(payload).await?;
 
-    println!("Saving memproof to local file...");
+    debug!("Saving memproof to local file...");
     save_mem_proof_to_file(&mem_proof_str, &memproof_path)?;
 
     debug!("Using memproof downloaded from Membrane Proof server");


### PR DESCRIPTION
 ### Updates:
 - Renames `HHAAgent` to `CoreAppAgent`
 - Adds the clone trait to `CoreAppAgent` and `HfAgent`.
 - Adds check in `AppConnection.connect()` to avoid attaching new app interfaces for app interfaces that already exist 

> NB: This is needed in holo-matching-services
> matching services pr: https://github.com/Holo-Host/holo-matching-services/pull/53