### PR TITLE
Fix/retry init app connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "isahc",
  "lair_keystore_api",
  "lazy_static",
+ "log",
  "mr_bundle",
  "reqwest",
  "rmp-serde",

--- a/crates/hpos_connect_hc/Cargo.toml
+++ b/crates/hpos_connect_hc/Cargo.toml
@@ -20,7 +20,6 @@ url = "2.4.0"
 isahc = "1.7.2"
 tempfile = "3.1"
 thiserror = "1.0"
-serde = { workspace = true }
 holochain_types = { workspace = true }
 holochain_conductor_api = { workspace = true }
 holochain_websocket = { workspace = true }
@@ -35,3 +34,5 @@ url2 = "0.0.6"
 holofuel_types = { workspace = true }
 chrono = "0.4.19"
 const_env = "0.1"
+serde = { workspace = true }
+log = "0.4.17"

--- a/crates/hpos_connect_hc/src/hf_agent.rs
+++ b/crates/hpos_connect_hc/src/hf_agent.rs
@@ -40,7 +40,7 @@ impl HfAgent {
             holofuel.id()
         };
 
-        let app = AppConnection::connect(&mut admin_ws, keystore, holofuel_id)
+        let app = AppConnection::connect(&mut admin_ws, keystore, holofuel_id, false)
             .await
             .context("failed to connect to holochain's app interface")?;
 

--- a/crates/hpos_connect_hc/src/hha_agent.rs
+++ b/crates/hpos_connect_hc/src/hha_agent.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, Context, Result};
 use holochain_keystore::AgentPubKeyExt;
 use holochain_types::dna::{ActionHashB64, AgentPubKey};
 use holochain_types::prelude::{FunctionName, Signature, ZomeName};
+use log::warn;
 
 // NOTE: This should really be renamed CORE_APP_AGENT, as it related to the core app and therfore connects to BOTH hha and hf
 /// Struct giving access to local instance of HHA on HPOS
@@ -41,9 +42,22 @@ impl CoreAppAgent {
         )
         .await?;
 
-        let app = AppConnection::connect(&mut admin_ws, keystore, core_app.id())
-            .await
-            .context("failed to connect to holochain's app interface")?;
+        let app = match AppConnection::connect(
+            &mut admin_ws,
+            keystore.clone(),
+            core_app.id(),
+            false,
+        )
+        .await
+        {
+            Ok(conn) => conn,
+            Err(err) => {
+                warn!("Failed to connnect to existing app websocket for core happ id: {:?}... creating and connecting to a new one.  Error: {:#?}", core_app.id(), err);
+                AppConnection::connect(&mut admin_ws, keystore, core_app.id(), true)
+                    .await
+                    .context("Failed to connect to holochain's app interface")?
+            }
+        };
 
         Ok(Self { app })
     }


### PR DESCRIPTION
This adds a catch case for whenever the identified app connection is down or unable to be established.  Whenever that happens this attempts to create a new app interface connection a single time, and if that fails, then it throws the ws error as before.