### PR TITLE
Fix: fetch-criteria call

### DIFF
--- a/crates/configure-holochain/src/jurisdictions.rs
+++ b/crates/configure-holochain/src/jurisdictions.rs
@@ -19,7 +19,7 @@ struct HostingCriteria {
 
 pub async fn get_jurisdiction() -> Result<String> {
     let output: Output = Command::new("hpos-holochain-client")
-        .args(["--url=http://localhost/holochain-api/", "hosting-criteria"])
+        .args(["--url=http://localhost/api/v2/", "hosting-criteria"])
         .output()?;
 
     let output_str = String::from_utf8_lossy(&output.stdout).to_string();

--- a/crates/core_app_cli/src/actions/get_all_happs_by.rs
+++ b/crates/core_app_cli/src/actions/get_all_happs_by.rs
@@ -4,7 +4,7 @@ use hpos_hc_connect::{
     app_connection::CoreAppRoleName, hha_agent::CoreAppAgent, hha_types::PresentedHappBundle,
 };
 
-pub async fn get() -> Result<()> {
+pub async fn get(publisher_pubkey: String) -> Result<()> {
     let mut agent = CoreAppAgent::spawn(None).await?;
 
     let happs: Vec<PresentedHappBundle> = agent
@@ -12,14 +12,19 @@ pub async fn get() -> Result<()> {
         .zome_call_typed(
             CoreAppRoleName::HHA.into(),
             ZomeName::from("hha"),
-            FunctionName::from("get_my_happs"),
+            FunctionName::from("get_happs"),
             (),
         )
         .await?;
 
+    let publisher_happs: Vec<&PresentedHappBundle> = happs
+        .iter()
+        .filter(|h| h.provider_pubkey.to_string() == publisher_pubkey)
+        .collect();
+
     println!("===================");
-    println!("Your Published Happs are: ");
-    println!("{:?}", happs);
+    println!("All Published Happs by {} are: ", publisher_pubkey);
+    println!("{:?}", publisher_happs);
     println!("===================");
 
     Ok(())

--- a/crates/core_app_cli/src/actions/get_specific_happ_prefs.rs
+++ b/crates/core_app_cli/src/actions/get_specific_happ_prefs.rs
@@ -21,7 +21,10 @@ pub async fn get(pref_hash: String) -> Result<()> {
         .await?;
 
     println!("===================");
-    println!("All Hosts for Preference Hash {} are: ", pref_hash);
+    println!(
+        "Host Preference Details for Preference Hash {} are: ",
+        pref_hash
+    );
     println!("{:#?}", prefs);
     println!("===================");
 

--- a/crates/core_app_cli/src/actions/mod.rs
+++ b/crates/core_app_cli/src/actions/mod.rs
@@ -1,4 +1,5 @@
 pub mod enable_happ_for_host;
+pub mod get_all_happs_by;
 pub mod get_happ_hosts;
 pub mod get_happ_pref_for_host;
 pub mod get_specific_happ_prefs;

--- a/crates/core_app_cli/src/main.rs
+++ b/crates/core_app_cli/src/main.rs
@@ -17,8 +17,11 @@ pub enum Opt {
     #[structopt(name = "pay")]
     PayInvoice,
     /// List all happs published by me
-    #[structopt(name = "happs")]
+    #[structopt(name = "my-happs")]
     Happs,
+    /// List all happs by provided publisher
+    #[structopt(name = "publisher-happs")]
+    GetHappsForPublisher { publisher_pubkey: String },
     /// List all hosts for a happ by `happ_id``
     #[structopt(name = "hosts")]
     Hosts { happ_id: String },
@@ -26,7 +29,7 @@ pub enum Opt {
     #[structopt(name = "enable-happ")]
     EnableHappForHost { happ_id: String, host_id: String },
     /// Fetch the happ preferences associated with a happ preference hash
-    #[structopt(name = "prefs")]
+    #[structopt(name = "pref-details")]
     GetPreferenceByHash { pref_hash: String },
     /// Fetch the happ preference hash for a specific host for a specific happ
     #[structopt(name = "host-prefs")]
@@ -61,6 +64,9 @@ impl Opt {
             Opt::Hosts { happ_id } => core_app_cli::get_happ_hosts::get(happ_id).await?,
             Opt::GetPreferenceByHash { pref_hash } => {
                 core_app_cli::get_specific_happ_prefs::get(pref_hash).await?
+            }
+            Opt::GetHappsForPublisher { publisher_pubkey } => {
+                core_app_cli::get_all_happs_by::get(publisher_pubkey).await?
             }
             Opt::EnableHappForHost { happ_id, host_id } => {
                 core_app_cli::enable_happ_for_host::get(happ_id, host_id).await?

--- a/crates/hpos_connect_hc/src/hha_agent.rs
+++ b/crates/hpos_connect_hc/src/hha_agent.rs
@@ -11,7 +11,7 @@ use crate::{AdminWebsocket, AppConnection};
 use anyhow::{anyhow, Context, Result};
 use holochain_keystore::AgentPubKeyExt;
 use holochain_types::dna::{ActionHashB64, AgentPubKey};
-use holochain_types::prelude::{ExternIO, FunctionName, Signature, ZomeName};
+use holochain_types::prelude::{FunctionName, Signature, ZomeName};
 
 // NOTE: This should really be renamed CORE_APP_AGENT, as it related to the core app and therfore connects to BOTH hha and hf
 /// Struct giving access to local instance of HHA on HPOS


### PR DESCRIPTION
Updates the host address in the `fetch-criteria` url to point to the updated `hpos-rust-api` address.