### PR TITLE
Remove incorrect unused type

### DIFF
--- a/crates/core_app_cli/src/actions/pay_invoices.rs
+++ b/crates/core_app_cli/src/actions/pay_invoices.rs
@@ -48,7 +48,7 @@ pub async fn get() -> Result<()> {
         println!("Accepted tx: {:?}", hash);
         println!("Trying to complete, if this fails it will be completed by your schedular");
 
-        let _: EntryHashB64 = agent
+        let _ = agent
             .app
             .zome_call_typed(
                 CoreAppRoleName::Holofuel.into(),

--- a/crates/core_app_cli/src/actions/pay_invoices.rs
+++ b/crates/core_app_cli/src/actions/pay_invoices.rs
@@ -5,7 +5,7 @@ use holochain_types::prelude::{
 };
 use hpos_hc_connect::app_connection::CoreAppRoleName;
 use hpos_hc_connect::hha_agent::CoreAppAgent;
-use hpos_hc_connect::holofuel_types::{Pending, CounterSigningResponse} ;
+use hpos_hc_connect::holofuel_types::{CounterSigningResponse, Pending};
 use serde::{Deserialize, Serialize};
 
 pub async fn get() -> Result<()> {
@@ -59,7 +59,6 @@ pub async fn get() -> Result<()> {
             .await?;
 
         println!("CounterSigningResponse {:?}", countersigning_response);
-
     } else {
         println!("===================");
         println!("No pending invoices");

--- a/crates/core_app_cli/src/actions/pay_invoices.rs
+++ b/crates/core_app_cli/src/actions/pay_invoices.rs
@@ -5,7 +5,7 @@ use holochain_types::prelude::{
 };
 use hpos_hc_connect::app_connection::CoreAppRoleName;
 use hpos_hc_connect::hha_agent::CoreAppAgent;
-use hpos_hc_connect::holofuel_types::Pending;
+use hpos_hc_connect::holofuel_types::{Pending, CounterSigningResponse} ;
 use serde::{Deserialize, Serialize};
 
 pub async fn get() -> Result<()> {
@@ -48,7 +48,7 @@ pub async fn get() -> Result<()> {
         println!("Accepted tx: {:?}", hash);
         println!("Trying to complete, if this fails it will be completed by your schedular");
 
-        let _ = agent
+        let countersigning_response: CounterSigningResponse = agent
             .app
             .zome_call_typed(
                 CoreAppRoleName::Holofuel.into(),
@@ -57,6 +57,9 @@ pub async fn get() -> Result<()> {
                 hash,
             )
             .await?;
+
+        println!("CounterSigningResponse {:?}", countersigning_response);
+
     } else {
         println!("===================");
         println!("No pending invoices");

--- a/crates/hpos_connect_hc/src/holofuel_types.rs
+++ b/crates/hpos_connect_hc/src/holofuel_types.rs
@@ -39,6 +39,14 @@ pub struct Actionable {
     pub promise_actionable: Vec<Transaction>,
 }
 
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, Clone, PartialEq)]
+pub enum CounterSigningResponse {
+    Successful(EntryHashB64),
+    UnableToReachCounterparty(String),
+    FeeDropOff(String),
+    TimeDelayWait(String),
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, SerializedBytes)]
 #[serde(rename_all = "snake_case")]
 pub enum POS {


### PR DESCRIPTION
`complete_transactions` does not return an `EntryHashB64`.

It's possible we need to provide a type here (for `zome_call_typed` to work), but given that we don't consume it, I'm hoping not.

If we do need to provide a type, the exact type is about to change